### PR TITLE
avoid causing writes by setting save: false

### DIFF
--- a/HubitatPixelblazeDriver.groovy
+++ b/HubitatPixelblazeDriver.groovy
@@ -762,13 +762,13 @@ def setControl(String ctl_name, String values, String saveFlash="false") {
 // n should be in the range 0-100
 def setGlobalBrightness(BigDecimal n) {
     if (n > 0) {n = n / 100.0} // avoid weirdness around floating point zero
-    sendMsg("{ \"brightness\" : ${n} }" )
+    sendMsg("{ \"brightness\" : ${n}, \"save\": false }" )
 }
  
 def setActivePattern(name) {
    def pid = getPatternId(name)
    if (pid) {    
-     def str = "{ \"activeProgramId\" : \"${pid[0]}\" }"
+     def str = "{ \"activeProgramId\" : \"${pid[0]}\", \"save\": false }"
      sendMsg(str)  
      sendEvent([name: "activePattern", value: name]) 
      sendEvent([name:"effectName", value:name])               


### PR DESCRIPTION
First, thank you for this driver, many folks have used it to great benefit and a few have used a PB because this exist!

The idea is to set save: false on some messages that could cause a write. Brightness writes the config by default. activeProgramId doesn't but can save the config if save: true is set. I could see how some kind of brightness fading automation could cause a lot of writes.

Non-persistence seems to be the theme, so I think this fits, and makes it easy to see where things would have to change to save settings.

Heads up: I don't have a setup to test this at all. There could be basic syntax errors if I didn't eyeball it right.
